### PR TITLE
Passing in package directory as cwd

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -3,4 +3,4 @@ var path = require('path')
 var homerun = require('./')
 var pkg = require(__dirname + '/../../package.json')
 
-homerun(pkg.scripts, process.argv).spawn()
+homerun(pkg.scripts, process.argv, __dirname + '/../../').spawn()

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var cp = require('child_process')
 var parse = require('shell-quote').parse
 
-module.exports = function(scripts, argv) {
+module.exports = function(scripts, argv, cwd) {
   process.env.PATH =  './node_modules/.bin:' + process.env.PATH
 
   // Extract args
@@ -33,7 +33,8 @@ module.exports = function(scripts, argv) {
 
         // Spawn
         return cp.spawn(cmd, argArray, {
-            stdio: 'inherit'
+            stdio: 'inherit',
+            cwd: cwd
           })
           .on('error', function(err) {
             console.error(err)
@@ -47,7 +48,7 @@ module.exports = function(scripts, argv) {
     },
     exec: function(cb) {
       if (script) {
-        return cp.exec(script + ' ' + argString, cb)
+        return cp.exec(script + ' ' + argString, {cwd: cwd}, cb)
       } else {
         cb({ code: 1 }, '', '')
       }


### PR DESCRIPTION
Generally npm run ____ expects the user to be in the directory where package.json defines them, otherwise the referencing relative files is broken.
